### PR TITLE
Metadata flagged partials

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,8 @@ To increase performance it is recommended you only include the exact template da
 
 If your partial only needs to be rendered once per (re)generation then you can specify `cacheable: true` in the partial's meta data, doing so greatly improves performance.
 
+An alternate to using the ```src/partials``` folder is to instead include ```isPartial: true``` in a document's metadata. This will prevent that document from being written during generation, but will make it available as a partial. The above guidelines around referencing (e.g. ```<%- @partial('metadata-flagged-partial', false, { localState: true }) %>```) apply.
+
 Partials actually render asynchronously, when you call `<%- @partial('hello') %>` you'll actually get back something a temporary placeholder like `[partial:0.1290219301293]` while your template is rendering, then once your template has rendered, and once all the partials have rendered, we will then go through and replace these placeholder values with the correct content. We must do this as template rendering is a synchronous process whereas document rendering is an asynchronous process. [More info here.](https://github.com/docpad/docpad-plugin-partials/issues/12)
 
 

--- a/src/partials.plugin.coffee
+++ b/src/partials.plugin.coffee
@@ -162,7 +162,12 @@ module.exports = (BasePlugin) ->
 
 				# Fetch our partial
 				partialFuzzyPath = pathUtil.join(config.partialsPath, partialName)
-				partial.document ?= docpad.getCollection('partials').fuzzyFindOne(partialFuzzyPath)
+				partialCollection = docpad.getCollection(config.collectionName)
+				partial.document ?= partialCollection.fuzzyFindOne(partialFuzzyPath)
+				partial.document ?= partialCollection.findOne({ filename: $startsWith: partialName })
+				partial.document ?= partialCollection.findOne({ basename: partialName })
+				partial.document ?= partialCollection.findOne({ relativeBase: partialName })
+				partial.document ?= partialCollection.findOne({ relativeOutPath: partialName })
 				unless partial.document
 					# Partial was not found
 					message = util.format(locale.partialNotFound, partialName)

--- a/src/partials.plugin.coffee
+++ b/src/partials.plugin.coffee
@@ -95,6 +95,7 @@ module.exports = (BasePlugin) ->
 				})
 				.on('add', (model) ->
 					docpad.log('debug', util.format(locale.addingPartial, model.getFilePath()))
+					docpad.log('warning', model)
 					model.setDefaults(
 						isPartial: true
 						render: false
@@ -162,7 +163,12 @@ module.exports = (BasePlugin) ->
 
 				# Fetch our partial
 				partialFuzzyPath = pathUtil.join(config.partialsPath, partialName)
-				partial.document ?= docpad.getCollection('partials').fuzzyFindOne(partialFuzzyPath)
+				partialCollection = docpad.getCollection(config.collectionName)
+				partial.document ?= partialCollection.fuzzyFindOne(partialFuzzyPath)
+				partial.document ?= partialCollection.findOne({ filename: $startsWith: partialName })
+				partial.document ?= partialCollection.findOne({ basename: partialName })
+				partial.document ?= partialCollection.findOne({ relativeBase: partialName })
+				partial.document ?= partialCollection.findOne({ relativeOutPath: partialName })
 				unless partial.document
 					# Partial was not found
 					message = util.format(locale.partialNotFound, partialName)

--- a/src/partials.plugin.coffee
+++ b/src/partials.plugin.coffee
@@ -95,7 +95,6 @@ module.exports = (BasePlugin) ->
 				})
 				.on('add', (model) ->
 					docpad.log('debug', util.format(locale.addingPartial, model.getFilePath()))
-					docpad.log('warning', model)
 					model.setDefaults(
 						isPartial: true
 						render: false

--- a/test/out-expected/partials.html
+++ b/test/out-expected/partials.html
@@ -33,3 +33,13 @@
 
 <!-- With a partial containing the same partial -->
 <header>Hello <header>Hello World. Site date is defined no</header>. Site date is defined no</header>
+
+<!-- A partial by way of setting metadata (isPartial: true) -->
+<div>Metadata-flagged partial</div>
+<div>Metadata-flagged partial</div>
+
+<!-- A partial by way of setting metadata (isPartial: true), located in a subfolder -->
+<div>Metadata-flagged partial in subfolder</div>
+<div>Metadata-flagged partial in subfolder</div>
+<div>Metadata-flagged partial in subfolder</div>
+<div>Metadata-flagged partial in subfolder</div>

--- a/test/src/documents/folder/metadata-flagged-partial-in-folder.html
+++ b/test/src/documents/folder/metadata-flagged-partial-in-folder.html
@@ -1,0 +1,5 @@
+---
+isPartial: true
+cacheable: true
+---
+<div>Metadata-flagged partial in subfolder</div>

--- a/test/src/documents/metadata-flagged-partial.html
+++ b/test/src/documents/metadata-flagged-partial.html
@@ -1,0 +1,5 @@
+---
+isPartial: true
+cacheable: true
+---
+<div>Metadata-flagged partial</div>

--- a/test/src/documents/partials.html.eco
+++ b/test/src/documents/partials.html.eco
@@ -37,3 +37,13 @@ title: 'Partials Test'
 
 <!-- With a partial containing the same partial -->
 <%- @partial('header.html.eco', false, {name: @partial('header.html.eco', false)}) %>
+
+<!-- A partial by way of setting metadata (isPartial: true) -->
+<%- @partial('metadata-flagged-partial.html') %>
+<%- @partial('metadata-flagged-partial') %>
+
+<!-- A partial by way of setting metadata (isPartial: true), located in a subfolder -->
+<%- @partial('folder/metadata-flagged-partial-in-folder.html') %>
+<%- @partial('folder/metadata-flagged-partial-in-folder') %>
+<%- @partial('metadata-flagged-partial-in-folder.html') %>
+<%- @partial('metadata-flagged-partial-in-folder') %>


### PR DESCRIPTION
[Fixes #31]

Instead of supplementing the query array in ```fuzzyFindOne()```, I opted for a localised solution: calling ```findOne()``` directly with additional queries.

These additional queries are only called should ```fuzzyFindOne()``` return ```null```. And indeed they short-circuit to give the best performance.

Tests and the plugin's ```README.md``` is also changed to reflect the solution.